### PR TITLE
feat: model predict methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist-ssr
 .env
 .env*
 .parcel-cache
+
+# build outputs
+*.tgz

--- a/README.md
+++ b/README.md
@@ -66,3 +66,57 @@ const response = await workflow.predict({
 
 console.log(response);
 ```
+
+### Using Clarifai GRPC directly
+
+If you were previously using the [clarifai-nodejs-grpc](https://github.com/clarifai/clarifai-nodejs-grpc) package or you want to access the full range of Clarifai API features, you can use the GRPC client directly.
+
+```typescript
+import {
+  PostModelOutputsRequest,
+  V2Client,
+} from "clarifai-node-serverless/grpc/proto/clarifai/api/service";
+import { ChannelCredentials, Metadata } from "@grpc/grpc-js";
+import { StatusCode } from "clarifai-node-serverless/grpc/proto/clarifai/api/status/status_code";
+
+const client = new V2Client(
+  "api.clarifai.com:443",
+  ChannelCredentials.createSsl(),
+);
+
+const postModelOutputsRequest = PostModelOutputsRequest.fromPartial({
+  modelId: "aaa03c23b3724a16a56b629203edc62c",
+  inputs: [
+    {
+      data: {
+        image: {
+          url: "https://samples.clarifai.com/dog2.jpeg",
+        },
+      },
+    },
+  ],
+});
+
+const metadata = new Metadata();
+metadata.set("authorization", `key ${process.env.CLARIFAI_PAT}`);
+
+client.postModelOutputs(postModelOutputsRequest, metadata, (err, response) => {
+  if (err) {
+    console.log("Error: " + err);
+    return;
+  }
+
+  if (response?.status?.code !== StatusCode.SUCCESS) {
+    console.log(
+      "Received failed status: " +
+        response?.status?.description +
+        "\n" +
+        response?.status?.details,
+    );
+    return;
+  }
+
+  console.log("results:");
+  console.log(response?.outputs);
+});
+```

--- a/esbuild.ts
+++ b/esbuild.ts
@@ -38,3 +38,26 @@ esbuild.build({
   platform: "node",
   outfile: "dist/module.js",
 });
+
+// Build Core GRPC files
+// CJS
+esbuild.build({
+  entryPoints: ["src/generated/**/*.ts"],
+  outdir: "dist/grpc/cjs/",
+  platform: "node",
+  format: "cjs",
+  bundle: false,
+  sourcemap: true,
+  target: "esnext",
+});
+
+// ESM
+esbuild.build({
+  entryPoints: ["src/generated/**/*.ts"],
+  outdir: "dist/grpc/esm/",
+  platform: "node",
+  format: "esm",
+  bundle: false,
+  sourcemap: true,
+  target: "esnext",
+});

--- a/package.json
+++ b/package.json
@@ -5,14 +5,21 @@
   "source": "src/index.ts",
   "main": "./dist/main.js",
   "module": "./dist/module.js",
-  "types": "./dist/types.d.ts",
+  "types": "./dist/types/index.d.ts",
   "exports": {
-    "import": "./dist/module.js",
-    "require": "./dist/main.js",
-    "types": "./dist/types.d.ts"
+    ".": {
+      "import": "./dist/module.js",
+      "require": "./dist/main.js",
+      "types": "./dist/types/index.d.ts"
+    },
+    "./grpc/*": {
+      "import": "./dist/grpc/esm/*.js",
+      "require": "./dist/grpc/cjs/*.js",
+      "types": "./dist/types/generated/*.d.ts"
+    }
   },
   "scripts": {
-    "build": "npx tsx esbuild.ts",
+    "build": "npx tsx esbuild.ts && tsc",
     "generate:proto": "sh initialize.sh",
     "lint": "tsc --noEmit"
   },

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -1,0 +1,16 @@
+import { V2Client } from "../generated/proto/clarifai/api/service";
+import { ChannelCredentials } from "@grpc/grpc-js";
+
+const MAX_MESSAGE_LENGTH = 1024 * 1024 * 1024; // 1GB
+const requestOptions = {
+  "grpc.max_receive_message_length": MAX_MESSAGE_LENGTH,
+  "grpc.max_send_message_length": MAX_MESSAGE_LENGTH,
+};
+
+export const getClient = (base?: string) => {
+  return new V2Client(
+    base || "api.clarifai.com:443",
+    ChannelCredentials.createSsl(),
+    requestOptions,
+  );
+};

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,4 +1,4 @@
-import { ChannelCredentials, Metadata } from "@grpc/grpc-js";
+import { Metadata } from "@grpc/grpc-js";
 import { MAX_WORKFLOW_PREDICT_INPUTS } from "./constants/workflow";
 import {
   Input as GrpcInput,
@@ -8,7 +8,6 @@ import { promisify } from "node:util";
 import {
   PostWorkflowResultsRequest,
   PostWorkflowResultsResponse,
-  V2Client,
 } from "./generated/proto/clarifai/api/service";
 import { AuthConfig } from "./types";
 import { ClarifaiUrl, ClarifaiUrlHelper } from "./urls/helper";
@@ -16,6 +15,7 @@ import { getMetaData } from "./utils/getMetadata";
 import { StatusCode } from "./generated/proto/clarifai/api/status/status_code";
 import { BackoffIterator } from "./utils/misc";
 import { getInputFromBytes, getInputFromUrl } from "./input";
+import { getClient } from "./utils/client";
 
 type Input = GrpcInput;
 
@@ -105,10 +105,7 @@ export class Workflow {
         : undefined,
     });
 
-    const client = new V2Client(
-      this.authConfig.base || "api.clarifai.com:443",
-      ChannelCredentials.createSsl(),
-    );
+    const client = getClient(this.authConfig.base);
 
     const postWorkflowResults = promisify<
       (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "moduleDetection": "force",
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outFile": "./dist/types.d.ts",
+    "outDir": "./dist/types",
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
This pull request introduces support for direct GRPC usage and improves the packaging and build process for GRPC-related files. The most significant changes are the addition of GRPC build steps, updates to `package.json` exports, and refactoring to centralize GRPC client creation.

**GRPC Support and Packaging Improvements:**

* Added GRPC build steps to `esbuild.ts` to output both CJS and ESM builds for files in `src/generated`, enabling easier consumption of GRPC proto files.
* Updated `package.json` to export GRPC modules and types under the `./grpc/*` path, and changed the main types entry to `./dist/types/index.d.ts` for better type resolution.

**Client Creation Refactor:**

* Introduced a new utility function `getClient` in `src/utils/client.ts` to construct a `V2Client` with appropriate options and credentials, centralizing GRPC client creation logic.
* Refactored `src/workflow.ts` to use the new `getClient` utility instead of directly constructing `V2Client`, simplifying code and ensuring consistent client configuration. [[1]](diffhunk://#diff-a7bb59c2cfe8284dd1986bd9b2bc4500d22233175f9e2705f5888f5902310b39L1-R1) [[2]](diffhunk://#diff-a7bb59c2cfe8284dd1986bd9b2bc4500d22233175f9e2705f5888f5902310b39L11-R18) [[3]](diffhunk://#diff-a7bb59c2cfe8284dd1986bd9b2bc4500d22233175f9e2705f5888f5902310b39L108-R108)

**Documentation:**

* Added a section to `README.md` demonstrating how to use the GRPC client directly, including a sample usage of `V2Client` and related types.